### PR TITLE
PYTHON-2378 Use PUT for EC2 token request, not POST

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Changes in Version 1.0.2
+------------------------
+
+- Fix a bug which caused MONGODB-AWS authentication to fail in some
+  EC2 Instance configurations. Previous versions incorrectly used a POST
+  request when creating the session token for Instance Metadata Service
+  Version 2 (IMDSv2).
+
 Changes in Version 1.0.1
 ------------------------
 

--- a/pymongo_auth_aws/auth.py
+++ b/pymongo_auth_aws/auth.py
@@ -70,8 +70,8 @@ def _aws_temp_credentials():
         try:
             # Get token
             headers = {'X-aws-ec2-metadata-token-ttl-seconds': "30"}
-            res = requests.post(_AWS_EC2_URI+'latest/api/token',
-                                headers=headers, timeout=_AWS_HTTP_TIMEOUT)
+            res = requests.put(_AWS_EC2_URI+'latest/api/token',
+                               headers=headers, timeout=_AWS_HTTP_TIMEOUT)
             token = res.content
             # Get role name
             headers = {'X-aws-ec2-metadata-token': token}

--- a/pymongo_auth_aws/auth.py
+++ b/pymongo_auth_aws/auth.py
@@ -56,9 +56,10 @@ def _aws_temp_credentials():
             res = requests.get(_AWS_REL_URI+relative_uri,
                                timeout=_AWS_HTTP_TIMEOUT)
             res_json = res.json()
-        except (ValueError, requests.exceptions.RequestException):
+        except (ValueError, requests.exceptions.RequestException) as exc:
             raise PyMongoAuthAwsError(
-                'temporary MONGODB-AWS credentials could not be obtained')
+                'temporary MONGODB-AWS credentials could not be obtained, '
+                'error: %s' % (exc,))
     else:
         # If the environment variable AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is
         # not set drivers MUST assume we are on an EC2 instance and use the
@@ -82,9 +83,10 @@ def _aws_temp_credentials():
             res = requests.get(_AWS_EC2_URI+_AWS_EC2_PATH+role,
                                headers=headers, timeout=_AWS_HTTP_TIMEOUT)
             res_json = res.json()
-        except (ValueError, requests.exceptions.RequestException):
+        except (ValueError, requests.exceptions.RequestException) as exc:
             raise PyMongoAuthAwsError(
-                'temporary MONGODB-AWS credentials could not be obtained')
+                'temporary MONGODB-AWS credentials could not be obtained, '
+                'error: %s' % (exc,))
 
     try:
         temp_user = res_json['AccessKeyId']


### PR DESCRIPTION
Tested here: https://evergreen.mongodb.com/version/5f6bc80f56234343be83cf9c

To install this fix before it's merged:
```
python -m pip install --upgrade https://github.com/ShaneHarvey/pymongo-auth-aws/archive/PYTHON-2378.tar.gz
```