### PR TITLE
DRIVERS-1746 Add native support for AWS IAM Roles for service accounts, EKS in particular

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ About
 =====
 
 MONGODB-AWS authentication support for PyMongo. pymongo-auth-aws uses
-`boto3`_ and `requests`_.
+`boto3`_, `botocore`_, and `requests`_.
 
 Support / Feedback
 ==================

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ About
 =====
 
 MONGODB-AWS authentication support for PyMongo. pymongo-auth-aws uses
-`botocore`_ and `requests`_.
+`boto3`_ and `requests`_.
 
 Support / Feedback
 ==================

--- a/pymongo_auth_aws/auth.py
+++ b/pymongo_auth_aws/auth.py
@@ -22,7 +22,6 @@ from collections import namedtuple
 import boto3
 import requests
 
-from botocore.exceptions import ClientError
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
 from botocore.credentials import Credentials

--- a/pymongo_auth_aws/auth.py
+++ b/pymongo_auth_aws/auth.py
@@ -55,18 +55,16 @@ def _aws_temp_credentials():
         try:
             with open(irsa_web_id_file) as f:
                 irsa_web_id_token = f.read()
-        # Check for errors raised by `open` from older Python versions.
-        except (OSError, IOError, InterruptedError) as exc:
-            raise PyMongoAuthAwsError(
-                'temporary MONGODB-AWS credentials could not be obtained, '
-                'error: %s' % (exc,))
-        try:
             return _irsa_assume_role(irsa_role_arn, irsa_web_id_token, 'pymongo-auth-aws')
-        except ClientError as error:
-            error_message = error.response['Error']['Message']
+        except ClientError as exc:
+            error_message = exc.response.get('error', {}).get('message') or exc
             raise PyMongoAuthAwsError(
                 'temporary MONGODB-AWS credentials could not be obtained, '
                 'error: %s' % (error_message,))
+        except Exception as exc:
+            raise PyMongoAuthAwsError(
+                'temporary MONGODB-AWS credentials could not be obtained, '
+                'error: %s' % (exc,))
     # If the environment variable
     # AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is set then drivers MUST
     # assume that it was set by an AWS ECS agent and use the URI

--- a/pymongo_auth_aws/auth.py
+++ b/pymongo_auth_aws/auth.py
@@ -56,11 +56,6 @@ def _aws_temp_credentials():
             with open(irsa_web_id_file) as f:
                 irsa_web_id_token = f.read()
             return _irsa_assume_role(irsa_role_arn, irsa_web_id_token, 'pymongo-auth-aws')
-        except ClientError as exc:
-            error_message = exc.response.get('error', {}).get('message') or exc
-            raise PyMongoAuthAwsError(
-                'temporary MONGODB-AWS credentials could not be obtained, '
-                'error: %s' % (error_message,))
         except Exception as exc:
             raise PyMongoAuthAwsError(
                 'temporary MONGODB-AWS credentials could not be obtained, '

--- a/pymongo_auth_aws/auth.py
+++ b/pymongo_auth_aws/auth.py
@@ -54,7 +54,8 @@ def _aws_temp_credentials():
         try:
             with open(irsa_web_id_file) as f:
                 irsa_web_id_token = f.read()
-            return _irsa_assume_role(irsa_role_arn, irsa_web_id_token, 'pymongo-auth-aws')
+            role_session_name = os.getenv('AWS_ROLE_SESSION_NAME', 'pymongo-auth-aws')
+            return _irsa_assume_role(irsa_role_arn, irsa_web_id_token, role_session_name)
         except Exception as exc:
             raise PyMongoAuthAwsError(
                 'temporary MONGODB-AWS credentials could not be obtained, '

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     description="MONGODB-AWS authentication support for PyMongo",
     long_description=LONG_DESCRIPTION,
     packages=find_packages(exclude=['test']),
-    install_requires=['requests<3.0.0', 'boto3'],
+    install_requires=['requests<3.0.0', 'boto3', 'botocore'],
     author="Shane Harvey",
     author_email="drivers-python-noreply@mongodb.com",
     url="https://github.com/mongodb/pymongo-auth-aws",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     description="MONGODB-AWS authentication support for PyMongo",
     long_description=LONG_DESCRIPTION,
     packages=find_packages(exclude=['test']),
-    install_requires=['requests<3.0.0', 'botocore'],
+    install_requires=['requests<3.0.0', 'boto3'],
     author="Shane Harvey",
     author_email="drivers-python-noreply@mongodb.com",
     url="https://github.com/mongodb/pymongo-auth-aws",


### PR DESCRIPTION
This PR adds support for Kubernetes environments using IAM Roles for Service Accounts (IRSA) to authenticate Pods. It looks for environment variables that are part of a standard IRSA configuration to fetch temporary credentials.

Resolves #8 