### PR TITLE
PYTHON-2818 Close client to avoid ResourceWarning

### DIFF
--- a/pymongo_auth_aws/auth.py
+++ b/pymongo_auth_aws/auth.py
@@ -184,7 +184,8 @@ def _irsa_assume_role(role_arn, token, role_session_name):
         RoleSessionName=role_session_name,
         WebIdentityToken=token
     )
-    sts_client.close()
+    if hasattr(sts_client, 'close'):
+        sts_client.close()
     creds = resp['Credentials']
     access_key = creds['AccessKeyId']
     secret_key = creds['SecretAccessKey']

--- a/pymongo_auth_aws/auth.py
+++ b/pymongo_auth_aws/auth.py
@@ -18,7 +18,6 @@ import os
 from functools import wraps
 
 from base64 import standard_b64encode
-from collections import namedtuple
 from datetime import tzinfo, timedelta, datetime
 
 
@@ -185,6 +184,7 @@ def _irsa_assume_role(role_arn, token, role_session_name):
         RoleSessionName=role_session_name,
         WebIdentityToken=token
     )
+    sts_client.close()
     creds = resp['Credentials']
     access_key = creds['AccessKeyId']
     secret_key = creds['SecretAccessKey']


### PR DESCRIPTION
```python
ResourceWarning: unclosed <ssl.SSLSocket fd=8, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('10.128.113.91', 55150), raddr=('52.119.198.216', 443)>
 [2022/08/22 21:01:49.212]   creds = _irsa_assume_role(irsa_role_arn, irsa_web_id_token, role_session_name)
```