### PR TITLE
PYTHON-3418 Make aws_temp_credentials public and use SDK to fetch credentials

### DIFF
--- a/pymongo_auth_aws/auth.py
+++ b/pymongo_auth_aws/auth.py
@@ -22,8 +22,6 @@ from datetime import tzinfo, timedelta, datetime
 
 
 import boto3
-import requests
-
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
 from botocore.credentials import Credentials
@@ -32,18 +30,12 @@ from botocore.utils import parse_to_aware_datetime
 from pymongo_auth_aws.errors import PyMongoAuthAwsError
 
 
-_AWS_REL_URI = 'http://169.254.170.2/'
-_AWS_EC2_URI = 'http://169.254.169.254/'
-_AWS_EC2_PATH = 'latest/meta-data/iam/security-credentials/'
-_AWS_HTTP_TIMEOUT = 10
-
 """MONGODB-AWS credentials."""
 class AwsCredential:
-    def __init__(self, username, password, token, expiration=None):
+    def __init__(self, username, password, token):
         self.username = username
         self.password = password
         self.token = token
-        self.expiration = expiration
 
 
 _credential_buffer_seconds = 60
@@ -93,122 +85,27 @@ class _UTC(tzinfo):
 utc = _UTC()
 
 
-def _aws_temp_credentials():
+def aws_temp_credentials():
     """Construct temporary MONGODB-AWS credentials."""
     # Store the variable locally for safe threaded access.
     use_cached_credentials = get_use_cached_credentials()
     creds = get_cached_credentials() if use_cached_credentials else None
-
-    access_key = os.environ.get('AWS_ACCESS_KEY_ID')
-    secret_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
-    if access_key and secret_key:
-        return AwsCredential(
-            access_key, secret_key, os.environ.get('AWS_SESSION_TOKEN'))
-
     # Check to see if we have valid credentials.
-    if creds and creds.expiration is not None:
-        now_utc = datetime.now(utc)
-        exp_utc = parse_to_aware_datetime(creds.expiration)
-        if (exp_utc - now_utc).total_seconds() >= _credential_buffer_seconds:
-            return creds
+    if creds and not creds.refresh_needed(_credential_buffer_seconds):
+        return AwsCredential(creds.access_key, creds.secret_key, creds.token)
 
-    # Check if environment variables exposed by IAM Roles for Service Accounts (IRSA) are present.
-    # See https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html for details.
-    irsa_web_id_file = os.getenv('AWS_WEB_IDENTITY_TOKEN_FILE')
-    irsa_role_arn = os.getenv('AWS_ROLE_ARN')
-    if irsa_web_id_file and irsa_role_arn:
-        try:
-            with open(irsa_web_id_file) as f:
-                irsa_web_id_token = f.read()
-            role_session_name = os.getenv('AWS_ROLE_SESSION_NAME', 'pymongo-auth-aws')
-            creds = _irsa_assume_role(irsa_role_arn, irsa_web_id_token, role_session_name)
-            if use_cached_credentials:
-                set_cached_credentials(creds)
-            return creds
-        except Exception as exc:
-            raise PyMongoAuthAwsError(
-                'temporary MONGODB-AWS credentials could not be obtained, '
-                'error: %s' % (exc,))
-
-    # If the environment variable
-    # AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is set then drivers MUST
-    # assume that it was set by an AWS ECS agent and use the URI
-    # http://169.254.170.2/$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI to
-    # obtain temporary credentials.
-    relative_uri = os.environ.get('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI')
-    if relative_uri is not None:
-        try:
-            res = requests.get(_AWS_REL_URI+relative_uri,
-                               timeout=_AWS_HTTP_TIMEOUT)
-            res_json = res.json()
-        except (ValueError, requests.exceptions.RequestException) as exc:
-            raise PyMongoAuthAwsError(
-                'temporary MONGODB-AWS credentials could not be obtained, '
-                'error: %s' % (exc,))
-    else:
-        # If the environment variable AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is
-        # not set drivers MUST assume we are on an EC2 instance and use the
-        # endpoint
-        # http://169.254.169.254/latest/meta-data/iam/security-credentials
-        # /<role-name>
-        # whereas role-name can be obtained from querying the URI
-        # http://169.254.169.254/latest/meta-data/iam/security-credentials/.
-        try:
-            # Get token
-            headers = {'X-aws-ec2-metadata-token-ttl-seconds': "30"}
-            res = requests.put(_AWS_EC2_URI+'latest/api/token',
-                               headers=headers, timeout=_AWS_HTTP_TIMEOUT)
-            token = res.content
-            # Get role name
-            headers = {'X-aws-ec2-metadata-token': token}
-            res = requests.get(_AWS_EC2_URI+_AWS_EC2_PATH, headers=headers,
-                               timeout=_AWS_HTTP_TIMEOUT)
-            role = res.text
-            # Get temp creds
-            res = requests.get(_AWS_EC2_URI+_AWS_EC2_PATH+role,
-                               headers=headers, timeout=_AWS_HTTP_TIMEOUT)
-            res_json = res.json()
-        except (ValueError, requests.exceptions.RequestException) as exc:
-            raise PyMongoAuthAwsError(
-                'temporary MONGODB-AWS credentials could not be obtained, '
-                'error: %s' % (exc,))
-
-    # See https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html#examples for expected result format.
     try:
-        temp_user = res_json['AccessKeyId']
-        temp_password = res_json['SecretAccessKey']
-        session_token = res_json['Token']
-        expiration = res_json['Expiration']
+        session = boto3.Session()
+        creds = session.get_credentials()
     except KeyError:
         # If temporary credentials cannot be obtained then drivers MUST
         # fail authentication and raise an error.
         raise PyMongoAuthAwsError(
             'temporary MONGODB-AWS credentials could not be obtained')
 
-    creds = AwsCredential(temp_user, temp_password, session_token, expiration)
-    if use_cached_credentials:
+    if use_cached_credentials and hasattr(creds, 'refresh_needed'):
         set_cached_credentials(creds)
-    return creds
-
-
-def _irsa_assume_role(role_arn, token, role_session_name):
-    """Call sts:AssumeRoleWithWebIdentity and return temporary credentials."""
-    sts_client = boto3.client('sts')
-    # See https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html.
-    resp = sts_client.assume_role_with_web_identity(
-        RoleArn=role_arn,
-        RoleSessionName=role_session_name,
-        WebIdentityToken=token
-    )
-    if hasattr(sts_client, 'close'):
-        sts_client.close()
-    creds = resp['Credentials']
-    access_key = creds['AccessKeyId']
-    secret_key = creds['SecretAccessKey']
-    session_token = creds['SessionToken']
-    expiration = creds['Expiration']
-
-    return AwsCredential(access_key, secret_key, session_token, expiration)
+    return AwsCredential(creds.access_key, creds.secret_key, creds.token)
 
 
 _AWS4_HMAC_SHA256 = 'AWS4-HMAC-SHA256'
@@ -314,7 +211,7 @@ class AwsSaslContext(object):
         # If a username and password are not provided, drivers MUST query
         # a link-local AWS address for temporary credentials.
         if self._credentials.username is None:
-            self._credentials = _aws_temp_credentials()
+            self._credentials = aws_temp_credentials()
 
         # Client first.
         client_nonce = os.urandom(32)

--- a/pymongo_auth_aws/auth.py
+++ b/pymongo_auth_aws/auth.py
@@ -111,6 +111,9 @@ def aws_temp_credentials():
         raise PyMongoAuthAwsError(
             'temporary MONGODB-AWS credentials could not be obtained')
 
+    # The botocore Credentials object does not expose the expiration
+    # directly, instead we use the refresh_needed method to determine
+    # whether the credentials are expired.
     refresh_needed = getattr(creds, 'refresh_needed', None)
     creds = AwsCredential(frozen.access_key, frozen.secret_key, frozen.token)
     # Only cache credentials that need to be refreshed from

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     description="MONGODB-AWS authentication support for PyMongo",
     long_description=LONG_DESCRIPTION,
     packages=find_packages(exclude=['test']),
-    install_requires=['requests<3.0.0', 'boto3', 'botocore'],
+    install_requires=['boto3', 'botocore'],
     extras_require={
         "test": ["requests_mock", "pymongo", "mock;python_version<'3.3'"]
     },

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=find_packages(exclude=['test']),
     install_requires=['boto3', 'botocore'],
     extras_require={
-        "test": ["requests_mock", "pymongo", "mock;python_version<'3.3'"]
+        "test": ["pymongo"]
     },
     author="Shane Harvey",
     author_email="drivers-python-noreply@mongodb.com",

--- a/test/test_pymongo_auth_aws.py
+++ b/test/test_pymongo_auth_aws.py
@@ -47,7 +47,7 @@ from test import unittest
 os.environ['AWS_SHARED_CREDENTIALS_FILE'] = '/tmp'
 AWS_DATE_FORMAT = r"%Y-%m-%dT%H:%M:%SZ"
 PORT = 8000
-URI = f'http://localhost:{PORT}'
+URI = 'http://localhost:%s' % PORT
 RESPONSE = None
 
 

--- a/test/test_pymongo_auth_aws.py
+++ b/test/test_pymongo_auth_aws.py
@@ -73,7 +73,8 @@ class TestAuthAws(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.httpd = socketserver.TCPServer(("", PORT), MockHandler)
-        cls.thread = threading.Thread(target=cls.httpd.serve_forever, daemon=False)
+        cls.thread = threading.Thread(target=cls.httpd.serve_forever)
+        cls.thread.setDaemon(False)
         cls.thread.start()
 
     @classmethod

--- a/test/test_pymongo_auth_aws.py
+++ b/test/test_pymongo_auth_aws.py
@@ -145,6 +145,23 @@ class TestAuthAws(unittest.TestCase):
         creds = aws_temp_credentials()
         self.ensure_equal(creds, expected)
 
+    def test_local_creds_not_cached(self):
+        os.environ['AWS_ACCESS_KEY_ID'] = 'foo'
+        os.environ['AWS_SECRET_ACCESS_KEY'] = 'bar'
+        creds = aws_temp_credentials()
+        self.assertEqual(creds.username, 'foo')
+        self.assertEqual(creds.password, 'bar')
+        self.assertEqual(creds.token, None)
+
+        os.environ['AWS_ACCESS_KEY_ID'] = 'fizz'
+        os.environ['AWS_SECRET_ACCESS_KEY'] = 'buzz'
+        creds = aws_temp_credentials()
+        del os.environ['AWS_ACCESS_KEY_ID']
+        del os.environ['AWS_SECRET_ACCESS_KEY']
+        self.assertEqual(creds.username, 'fizz')
+        self.assertEqual(creds.password, 'buzz')
+        self.assertEqual(creds.token, None)
+
     def test_caching_disabled(self):
         global RESPONSE
         auth.set_use_cached_credentials(False)

--- a/test/test_pymongo_auth_aws.py
+++ b/test/test_pymongo_auth_aws.py
@@ -18,14 +18,15 @@ from datetime import datetime, timedelta
 import threading
 import json
 import os
-import socketserver
 import sys
 import tempfile
 
 try:
     from http.server import  SimpleHTTPRequestHandler
+    import socketserver
 except ImportError:  # python 2
     from SimpleHTTPServer  import SimpleHTTPRequestHandler
+    import SocketServer as socketserver
 
 sys.path[0:0] = [""]
 

--- a/test/test_pymongo_auth_aws.py
+++ b/test/test_pymongo_auth_aws.py
@@ -28,19 +28,19 @@ sys.path[0:0] = [""]
 
 import botocore.session
 from botocore.stub import Stubber
+import requests_mock
 
 import bson
 from bson.binary import Binary
 import pymongo_auth_aws
-import requests_mock
 
 from pymongo_auth_aws import auth
-from pymongo_auth_aws.auth import _get_region, _aws_temp_credentials, AwsSaslContext, AwsCredential
+from pymongo_auth_aws.auth import _get_region, aws_temp_credentials, AwsSaslContext, AwsCredential
 from pymongo_auth_aws.errors import PyMongoAuthAwsError
 
 from test import unittest
 
-
+os.environ['AWS_SHARED_CREDENTIALS_FILE'] = '/tmp'
 AWS_DATE_FORMAT = r"%Y-%m-%dT%H:%M:%SZ"
 
 class TestAuthAws(unittest.TestCase):
@@ -81,140 +81,89 @@ class TestAuthAws(unittest.TestCase):
             self.assertEqual(creds.token, expected['SessionToken'])
         else:
             self.assertEqual(creds.token, expected['Token'])
-        self.assertEqual(creds.expiration, expected['Expiration'])
 
     def test_aws_temp_credentials_env_variables(self):
         os.environ['AWS_ACCESS_KEY_ID'] = 'foo'
         os.environ['AWS_SECRET_ACCESS_KEY'] = 'bar'
-        creds = _aws_temp_credentials()
+        creds = aws_temp_credentials()
         del os.environ['AWS_ACCESS_KEY_ID']
         del os.environ['AWS_SECRET_ACCESS_KEY']
         self.assertEqual(creds.username, 'foo')
         self.assertEqual(creds.password, 'bar')
         self.assertEqual(creds.token, None)
-        self.assertEqual(creds.expiration, None)
 
-    def test_aws_temp_credentials_relative_url(self):
-        os.environ['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = 'foo'
+    def test_aws_temp_credentials(self):
+        os.environ['AWS_CONTAINER_CREDENTIALS_FULL_URI'] = uri = 'https://localhost'
         expected = dict(AccessKeyId='foo', SecretAccessKey='bar', Token='fizz', Expiration='2016-03-15T00:05:07Z')
         with requests_mock.Mocker() as m:
-            m.get('%sfoo' % auth._AWS_REL_URI, json=expected)
-            creds = _aws_temp_credentials()
-        self.ensure_equal(creds, expected)
-
-    def test_aws_temp_credentials_ec2(self):
-        expected = dict(AccessKeyId='foo', SecretAccessKey='bar', Token='fizz', Expiration='2016-03-15T00:05:07Z')
-        with requests_mock.Mocker() as m:
-            m.put('%slatest/api/token' % auth._AWS_EC2_URI, text='foo')
-            m.get('%s%s' % (auth._AWS_EC2_URI, auth._AWS_EC2_PATH), text='bar')
-            m.get('%s%sbar' % (auth._AWS_EC2_URI, auth._AWS_EC2_PATH), json=expected)
-            creds = _aws_temp_credentials()
+            m.get(uri, json=expected)
+            creds = aws_temp_credentials()
         self.ensure_equal(creds, expected)
 
     def test_cache_credentials(self):
         auth.set_use_cached_credentials(True)
-        os.environ['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = 'foo'
+        os.environ['AWS_CONTAINER_CREDENTIALS_FULL_URI'] = uri = 'https://localhost'
         tomorrow = datetime.now(auth.utc) + timedelta(days=1)
         expected = dict(AccessKeyId='foo', SecretAccessKey='bar', Token='fizz', Expiration=tomorrow.strftime(AWS_DATE_FORMAT))
         with requests_mock.Mocker() as m:
-            m.get('%sfoo' % auth._AWS_REL_URI, json=expected)
-            creds = _aws_temp_credentials()
+            m.get(uri, json=expected)
+            creds = aws_temp_credentials()
         self.ensure_equal(creds, expected)
 
-        creds = _aws_temp_credentials()
+        creds = aws_temp_credentials()
         self.ensure_equal(creds, expected)
 
     def test_caching_disabled(self):
         auth.set_use_cached_credentials(False)
-        os.environ['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = 'foo'
+        os.environ['AWS_CONTAINER_CREDENTIALS_FULL_URI'] = uri = 'https://localhost'
         soon = datetime.now(auth.utc) + timedelta(minutes=10)
         expected = dict(AccessKeyId='foo', SecretAccessKey='bar', Token='fizz', Expiration=soon.strftime(AWS_DATE_FORMAT))
         with requests_mock.Mocker() as m:
-            m.get('%sfoo' % auth._AWS_REL_URI, json=expected)
-            creds = _aws_temp_credentials()
+            m.get(uri, json=expected)
+            creds = aws_temp_credentials()
         self.ensure_equal(creds, expected)
 
         tomorrow = datetime.now(auth.utc) + timedelta(days=1)
         expected['Expiration'] = tomorrow.strftime(AWS_DATE_FORMAT)
         with requests_mock.Mocker() as m:
             m.get('%sfoo' % auth._AWS_REL_URI, json=expected)
-            creds = _aws_temp_credentials()
+            creds = aws_temp_credentials()
         self.ensure_equal(creds, expected)
 
     def test_cache_expired(self):
         auth.set_use_cached_credentials(True)
-        os.environ['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = 'foo'
+        os.environ['AWS_CONTAINER_CREDENTIALS_FULL_URI'] = uri = 'https://localhost'
         expired = datetime.now(auth.utc) - timedelta(hours=1)
         expected = dict(AccessKeyId='foo', SecretAccessKey='bar', Token='fizz', Expiration=expired.strftime(AWS_DATE_FORMAT))
         with requests_mock.Mocker() as m:
-            m.get('%sfoo' % auth._AWS_REL_URI, json=expected)
-            creds = _aws_temp_credentials()
+            m.get(uri, json=expected)
+            creds = aws_temp_credentials()
 
         self.ensure_equal(creds, expected)
 
         expected['AccessKeyId'] = 'fizz'
         with requests_mock.Mocker() as m:
-            m.get('%sfoo' % auth._AWS_REL_URI, json=expected)
-            creds = _aws_temp_credentials()
+            m.get(uri, json=expected)
+            creds = aws_temp_credentials()
 
         self.ensure_equal(creds, expected)
 
     def test_cache_expires_soon(self):
         auth.set_use_cached_credentials(True)
-        os.environ['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = 'foo'
+        os.environ['AWS_CONTAINER_CREDENTIALS_FULL_URI'] = uri = 'https://localhost'
         soon = datetime.now(auth.utc) + timedelta(seconds=30)
         expected = dict(AccessKeyId='foo', SecretAccessKey='bar', Token='fizz', Expiration=soon.strftime(AWS_DATE_FORMAT))
         with requests_mock.Mocker() as m:
-            m.get('%sfoo' % auth._AWS_REL_URI, json=expected)
-            creds = _aws_temp_credentials()
+            m.get(uri, json=expected)
+            creds = aws_temp_credentials()
 
         self.ensure_equal(creds, expected)
 
         expected['AccessKeyId'] = 'fizz'
         with requests_mock.Mocker() as m:
-            m.get('%sfoo' % auth._AWS_REL_URI, json=expected)
-            creds = _aws_temp_credentials()
+            m.get(uri, json=expected)
+            creds = aws_temp_credentials()
 
-        self.ensure_equal(creds, expected)
-
-    def test_web_identity(self):
-        auth.set_use_cached_credentials(True)
-
-        def get_key():
-            return os.urandom(24).decode('utf-8', 'replace')
-
-        fd, path = tempfile.mkstemp('web_identity')
-        # From https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html.
-        web_token = "Atza%7CIQEBLjAsAhRFiXuWpUXuRvQ9PZL3GMFcYevydwIUFAHZwXZXXXXXXXXJnrulxKDHwy87oGKPznh0D6bEQZTSCzyoCtL_8S07pLpr0zMbn6w1lfVZKNTBdDansFBmtGnIsIapjI6xKR02Yc_2bQ8LZbUXSGm6Ry6_BG7PrtLZtj_dfCTj92xNGed-CrKqjG7nPBjNIL016GGvuS5gSvPRUxWES3VYfm1wl7WTI7jn-Pcb6M-buCgHhFOzTQxod27L9CqnOLio7N3gZAGpsp6n1-AJBOCJckcyXe2c6uD0srOJeZlKUm2eTDVMf8IehDVI0r1QOnTV6KzzAI3OY87Vd_cVMQ"
-        os.write(fd, web_token.encode('utf-8'))
-        os.close(fd)
-
-        os.environ['AWS_WEB_IDENTITY_TOKEN_FILE'] = path
-        os.environ['AWS_ROLE_ARN'] = role_arn = 'arn:aws:iam::123456789012:role/FederatedWebIdentityRole'
-        os.environ['AWS_ROLE_SESSION_NAME'] = role_session_name = 'app1'
-
-        tomorrow = datetime.now(auth.utc) + timedelta(days=1)
-        expected = dict(AccessKeyId=get_key(), SecretAccessKey=get_key(), SessionToken=get_key(), Expiration=tomorrow.strftime(AWS_DATE_FORMAT))
-
-        sts = botocore.session.get_session().create_client('sts')
-        with patch('pymongo_auth_aws.auth.boto3') as mock_boto3:
-            with Stubber(sts) as stubber:
-                mock_boto3.client.return_value = sts
-                response = {
-                    'Credentials': expected
-                }
-                expected_params = {
-                    'RoleArn': role_arn,
-                    'RoleSessionName': role_session_name,
-                    'WebIdentityToken': web_token
-                }
-                stubber.add_response('assume_role_with_web_identity', response, expected_params)
-                creds = _aws_temp_credentials()
-
-        self.ensure_equal(creds, expected)
-
-        # Ensure cached creds are used.
-        creds = _aws_temp_credentials()
         self.ensure_equal(creds, expected)
 
 
@@ -237,7 +186,7 @@ class _AwsSaslContext(AwsSaslContext):
 class TestAwsSaslContext(unittest.TestCase):
 
     def test_step(self):
-        creds = AwsCredential('foo', 'bar', 'baz', None)
+        creds = AwsCredential('foo', 'bar', 'baz')
         test = _AwsSaslContext(creds)
         response = bson.decode(test.step(None))
         nonce = response['r'] + os.urandom(32)

--- a/test/test_pymongo_auth_aws.py
+++ b/test/test_pymongo_auth_aws.py
@@ -15,7 +15,6 @@
 """Test the pymongo-auth-aws module."""
 
 from datetime import datetime, timedelta
-from http.server import  SimpleHTTPRequestHandler
 import threading
 import json
 import os
@@ -24,9 +23,9 @@ import sys
 import tempfile
 
 try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+    from http.server import  SimpleHTTPRequestHandler
+except ImportError:  # python 2
+    from SimpleHTTPServer  import SimpleHTTPRequestHandler
 
 sys.path[0:0] = [""]
 


### PR DESCRIPTION
Passes [patch build](https://spruce.mongodb.com/task/mongo_python_driver_aws_auth_test__platform~ubuntu_18.04_python_version~3.7_aws_auth_test_6.0_patch_0f135a157e2fa6ae66d4091186bdf0c40113ef77_630f866dc9ec4466ef124475_22_08_31_16_04_14/logs?execution=0) from pymongo, including web identity